### PR TITLE
Use an old commit for building linux to fix issue with cross compiling libgpg-error

### DIFF
--- a/build/build-native-code.sh
+++ b/build/build-native-code.sh
@@ -39,6 +39,10 @@ port_root="$repo_root/vcpkg/ports"
 echo "Configuring VCPKG at $vcpkg_root using ports at $port_root for triplet $triplet"
 
 test -d $vcpkg_root || git clone https://github.com/microsoft/vcpkg $vcpkg_root
+pushd $vcpkg_root
+git pull origin 727bdba9a3765a181cb6be9cb1f6aa01f2c2b5df
+git checkout FETCH_HEAD
+popd
 
 $vcpkg_root/bootstrap-vcpkg.sh
 

--- a/build/setup_vcpkg.sh
+++ b/build/setup_vcpkg.sh
@@ -21,7 +21,11 @@ fi
 
 echo Configuring VCPKG at $vcpkg_root using ports at $port_root for triplet $triplet
 
-git clone https://github.com/microsoft/vcpkg $vcpkg_root
+test -d $vcpkg_root || git clone https://github.com/microsoft/vcpkg $vcpkg_root
+
+pushd $vcpkg_root
+git pull origin 727bdba9a3765a181cb6be9cb1f6aa01f2c2b5df
+git checkout FETCH_HEAD
 
 $vcpkg_root/bootstrap-vcpkg.sh
 


### PR DESCRIPTION
Use an old commit for building linux to fix issue with cross compiling libgpg-error

When cross compiling libgpg-error to build arm64 or arm on amd64  linux, the build fails to invoke mkheader.
We chose this commit because it was near when the last known good build was (August 18, 2022) and the next commit is to a related package (libgcrypt).