### PR TITLE
v1.0.1 patch - Add missing file, 'DiffGenTool' from linux portion of nuget.

### DIFF
--- a/pipelines/templates/version-variables.yml
+++ b/pipelines/templates/version-variables.yml
@@ -5,7 +5,7 @@ variables:
   - name: minor_version
     value: 0
   - name: patch_version
-    value: 0
+    value: 1
   - name: semver_version
     value: '$(major_version).$(minor_version).$(patch_version)'
   - name: informational_version

--- a/src/managed/DiffGen/DiffGeneration/DiffGeneration.nuspec
+++ b/src/managed/DiffGen/DiffGeneration/DiffGeneration.nuspec
@@ -34,6 +34,6 @@
 
     <file src="ERRORS.md" target="." />
     
-    <file src="bin\**\*.*" target="bin" />
+    <file src="bin\**\*" target="bin" />
   </files>
 </package>

--- a/src/managed/DiffGen/DiffGeneration/WriteDiffToDisk.cs
+++ b/src/managed/DiffGen/DiffGeneration/WriteDiffToDisk.cs
@@ -25,24 +25,26 @@ namespace Microsoft.Azure.DeviceUpdate.Diffs
         {
             CheckForCancellation();
 
-            if (File.Exists(OutputFile))
+            var outputFile = Path.GetFullPath(OutputFile);
+
+            if (File.Exists(outputFile))
             {
-                Logger.LogInformation("Deleting existing file: {0}", OutputFile);
-                File.Delete(OutputFile);
+                Logger.LogInformation("Deleting existing file: {0}", outputFile);
+                File.Delete(outputFile);
             }
 
-            string outputDirectory = Path.GetDirectoryName(OutputFile);
+            string outputDirectory = Path.GetDirectoryName(outputFile);
             if (!Directory.Exists(outputDirectory))
             {
                 Directory.CreateDirectory(outputDirectory);
             }
 
-            Logger.LogInformation("Writing diff to {0}", OutputFile);
+            Logger.LogInformation("Writing diff to {0}", outputFile);
 
-            string path = OutputFile;
+            string path = outputFile;
             DiffSerializer.WriteDiff(Diff, path);
 
-            FileInfo diffFileInfo = new(OutputFile);
+            FileInfo diffFileInfo = new(outputFile);
             Logger.LogInformation($"Size: {diffFileInfo.Length:#,0.####} bytes");
         }
     }


### PR DESCRIPTION
v1.0.1 patch - Add missing file, 'DiffGenTool' from linux portion of nuget.
Allow for a simple file name to be supplied as output for DiffGenTool.