### PR TITLE
Change pipelines to produce 7z archive for diffgentool on windows and tar.gz for linux.

### DIFF
--- a/pipelines/onebranch/PullRequest/diffapi-linux-PullRequest.yml
+++ b/pipelines/onebranch/PullRequest/diffapi-linux-PullRequest.yml
@@ -31,7 +31,7 @@ variables:
   system.debug: ${{ parameters.debug }}
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -74,7 +74,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes
@@ -109,6 +109,7 @@ extends:
               publish: false
               copy_output: true
               copy_output_binaries: $(ob_outputDirectory)/managed
+              copy_output_archives: $(ob_outputDirectory)/archives
 
 # https://aka.ms/obpipelines/cloudtest
 # uncomment this section and edit parameters to enable CloudTest

--- a/pipelines/onebranch/PullRequest/diffapi-linux-arm-PullRequest.yml
+++ b/pipelines/onebranch/PullRequest/diffapi-linux-arm-PullRequest.yml
@@ -29,7 +29,7 @@ variables:
   system.debug: ${{ parameters.debug }}
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -72,7 +72,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes

--- a/pipelines/onebranch/PullRequest/diffapi-linux-arm64-PullRequest.yml
+++ b/pipelines/onebranch/PullRequest/diffapi-linux-arm64-PullRequest.yml
@@ -29,7 +29,7 @@ variables:
   system.debug: ${{ parameters.debug }}
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -72,7 +72,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes

--- a/pipelines/onebranch/PullRequest/diffapi-windows-PullRequest.yml
+++ b/pipelines/onebranch/PullRequest/diffapi-windows-PullRequest.yml
@@ -108,6 +108,7 @@ extends:
               publish: false
               copy_output: true
               copy_output_binaries: $(ob_outputDirectory)/managed
+              copy_output_archives: $(ob_outputDirectory)/archives
 
 # https://aka.ms/obpipelines/cloudtest
 # uncomment this section and edit parameters to enable CloudTest

--- a/pipelines/onebranch/PullRequest/diffapi-windows-debug-PullRequest.yml
+++ b/pipelines/onebranch/PullRequest/diffapi-windows-debug-PullRequest.yml
@@ -108,6 +108,7 @@ extends:
               publish: false
               copy_output: true
               copy_output_binaries: $(ob_outputDirectory)/managed
+              copy_output_archives: $(ob_outputDirectory)/archives
 
 # https://aka.ms/obpipelines/cloudtest
 # uncomment this section and edit parameters to enable CloudTest

--- a/pipelines/onebranch/diffapi-linux-arm-official.yml
+++ b/pipelines/onebranch/diffapi-linux-arm-official.yml
@@ -22,7 +22,7 @@ variables:
   ENABLE_PRS_DELAYSIGN: 1
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -67,7 +67,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes

--- a/pipelines/onebranch/diffapi-linux-arm64-official.yml
+++ b/pipelines/onebranch/diffapi-linux-arm64-official.yml
@@ -22,7 +22,7 @@ variables:
   ENABLE_PRS_DELAYSIGN: 1
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -67,7 +67,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes

--- a/pipelines/onebranch/diffapi-linux-official.yml
+++ b/pipelines/onebranch/diffapi-linux-official.yml
@@ -22,7 +22,7 @@ variables:
   ENABLE_PRS_DELAYSIGN: 1
   ROOT: $(Build.SourcesDirectory)
   REPOROOT: $(Build.SourcesDirectory)
-  OUTPUTROOT: $(REPOROOT)\out
+  OUTPUTROOT: $(REPOROOT)/out
   NUGET_XMLDOC_MODE: none
 
   LinuxContainerImage : 'onebranch.azurecr.io/linux/ubuntu-2204:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
@@ -67,7 +67,7 @@ extends:
         - template: /pipelines/variables/common-variables.yml@self
         - template: /pipelines/variables/diffgen-variables.yml@self
         - name: ob_outputDirectory
-          value: '$(REPOROOT)\out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          value: '$(REPOROOT)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
         - name: ob_sdl_binskim_break
           value: true # https://aka.ms/obpipelines/sdl
         - name: ob_sdl_codeSignValidation_excludes
@@ -104,6 +104,7 @@ extends:
               one_branch_signing: true
               copy_output: true
               copy_output_binaries: $(ob_outputDirectory)/managed
+              copy_output_archives: $(ob_outputDirectory)/archives
 
 # https://aka.ms/obpipelines/cloudtest
 # uncomment this section and edit parameters to enable CloudTest

--- a/pipelines/onebranch/diffapi-windows-official.yml
+++ b/pipelines/onebranch/diffapi-windows-official.yml
@@ -104,6 +104,7 @@ extends:
               one_branch_signing: true
               copy_output: true
               copy_output_binaries: $(ob_outputDirectory)/managed
+              copy_output_archives: $(ob_outputDirectory)/archives
 
 # https://aka.ms/obpipelines/cloudtest
 # uncomment this section and edit parameters to enable CloudTest

--- a/pipelines/templates/build-managed-linux.yml
+++ b/pipelines/templates/build-managed-linux.yml
@@ -18,6 +18,9 @@ parameters:
 - name: copy_output
   type: boolean
   default: false
+- name: copy_output_archives
+  type: string
+  default: ''
 - name: copy_output_binaries
   type: string
   default: ''
@@ -26,6 +29,12 @@ parameters:
   default: false
 
 steps:
+- task: Bash@3
+  displayName: 'Dump Environment Variables'
+  inputs:
+    targetType: inline
+    script: env
+
 - task: UseDotNet@2
   displayName: 'Use .NET Standard sdk'
   inputs:
@@ -79,3 +88,46 @@ steps:
       Contents: '*'
       TargetFolder: ${{ parameters.copy_output_binaries }}
 
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.SourcesDirectory)/src/managed/DiffGen/tools/DiffGenTool/bin/${{ parameters.build_configuration }}/net8.0/linux-x64'
+    archiveType: tar
+    tarCompression: gz
+    archiveFile: '$(Build.ArtifactStagingDirectory)/archives/DiffGenTool.${{ parameters.build_platform }}-windows.${{ parameters.build_configuration }}.tar.gz'
+    verbose: true
+
+- task: Bash@3
+  displayName: 'Show Archive'
+  inputs:
+    targetType: inline
+    script: tree $(Build.ArtifactStagingDirectory)/archives
+
+- ${{ if parameters.one_branch_signing }}:
+  - task: onebranch.pipeline.signing@1 # https://aka.ms/obpipelines/signing
+    displayName: 'Sign archive'
+    inputs:
+      command: 'sign'
+      signing_environment: 'azure-ado'
+      files_to_sign: '**/*.tar.gz'
+      search_root: '$(Build.ArtifactStagingDirectory)/archives'
+
+- ${{ if parameters.one_branch_signing }}:
+  - task: Bash@3
+    displayName: 'Show Signed Archive'
+    inputs:
+      targetType: inline
+      script: tree $(Build.ArtifactStagingDirectory)/archives
+
+- ${{ if parameters.copy_output }}:
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(Build.ArtifactStagingDirectory)/archives'
+      Contents: '*'
+      TargetFolder: ${{ parameters.copy_output_archives }}
+
+- ${{ if parameters.copy_output }}:
+  - task: Bash@3
+    displayName: 'Show Copied Archive'
+    inputs:
+      targetType: inline
+      script: tree ${{ parameters.copy_output_archives }}

--- a/pipelines/templates/build-managed-windows.yml
+++ b/pipelines/templates/build-managed-windows.yml
@@ -18,6 +18,9 @@ parameters:
 - name: copy_output
   type: boolean
   default: false
+- name: copy_output_archives
+  type: string
+  default: ''
 - name: copy_output_binaries
   type: string
   default: ''
@@ -88,3 +91,47 @@ steps:
       SourceFolder: '$(Build.SourcesDirectory)/src/managed/DiffGen/tools/DiffGenTool/bin/${{ parameters.build_configuration }}/net8.0/win-x64'
       Contents: '*'
       TargetFolder: ${{ parameters.copy_output_binaries }}
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.SourcesDirectory)/src/managed/DiffGen/tools/DiffGenTool/bin/${{ parameters.build_configuration }}/net8.0/win-x64'
+    archiveType: 7z
+    sevenZipCompression: ultra
+    archiveFile: '$(Build.ArtifactStagingDirectory)/archives/DiffGenTool.${{ parameters.build_platform }}-windows.${{ parameters.build_configuration }}.7z'
+    verbose: true
+
+- task: PowerShell@2
+  displayName: 'Show Archive'
+  inputs:
+    targetType: inline
+    script: tree /f $(Build.ArtifactStagingDirectory)/archives
+
+- ${{ if parameters.one_branch_signing }}:
+  - task: onebranch.pipeline.signing@1 # https://aka.ms/obpipelines/signing
+    displayName: 'Sign archive'
+    inputs:
+      command: 'sign'
+      signing_environment: 'azure-ado'
+      files_to_sign: '**/*.7z'
+      search_root: '$(Build.ArtifactStagingDirectory)/archives'
+
+- ${{ if parameters.one_branch_signing }}:
+  - task: PowerShell@2
+    displayName: 'Show Signed Archive'
+    inputs:
+      targetType: inline
+      script: tree /f $(Build.ArtifactStagingDirectory)/archives
+
+- ${{ if parameters.copy_output }}:
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(Build.ArtifactStagingDirectory)/archives'
+      Contents: '*'
+      TargetFolder: ${{ parameters.copy_output_archives }}
+
+- ${{ if parameters.copy_output }}:
+  - task: PowerShell@2
+    displayName: 'Show Copied Archive'
+    inputs:
+      targetType: inline
+      script: tree /f ${{ parameters.copy_output_archives }}


### PR DESCRIPTION
Update pipelines for managed build to produce archives for diffgentool using 7z for windows and tar.gz for linux.